### PR TITLE
Href markup

### DIFF
--- a/base/base.go
+++ b/base/base.go
@@ -55,23 +55,28 @@ func MarkupOnly(moc vecty.MarkupOrChild) *vecty.MarkupList {
 /*
 	Represents a simplified version of an element
 */
-type SimplifiedMarkup struct {
+type LinkMarkup struct {
 	Child          vecty.ComponentOrHTML
 	Href           string
 	OnClick        func(*vecty.Event)
 	PreventDefault bool
 }
 
-func ExtractMarkup(html *vecty.HTML) *SimplifiedMarkup {
-	sm := &SimplifiedMarkup{}
+func ExtractMarkupFromLink(html *vecty.HTML) *LinkMarkup {
+	sm := &LinkMarkup{}
 
 	h := reflect.ValueOf(*html)
 	tag := h.FieldByName("tag").String()
-	href := h.FieldByName("properties").
-		MapIndex(reflect.ValueOf("href")).Elem().String()
+	href := ""
+	if !h.FieldByName("properties").IsZero() {
+		href = h.FieldByName("properties").
+			MapIndex(reflect.ValueOf("href")).Elem().String()
+	}
 
 	if tag == "a" && href != "" {
 		sm.Href = href
+	} else {
+		return sm
 	}
 
 	for i := 0; i < h.FieldByName("eventListeners").Len(); i++ {

--- a/base/base.go
+++ b/base/base.go
@@ -75,8 +75,6 @@ func ExtractMarkupFromLink(html *vecty.HTML) *LinkMarkup {
 
 	if tag == "a" && href != "" {
 		sm.Href = href
-	} else {
-		return sm
 	}
 
 	for i := 0; i < h.FieldByName("eventListeners").Len(); i++ {

--- a/button/button.go
+++ b/button/button.go
@@ -16,17 +16,21 @@ type B struct {
 	Root       vecty.MarkupOrChild
 	Label      vecty.ComponentOrHTML
 	Icon       vecty.ComponentOrHTML
-	OnClick    func(this *B, e *vecty.Event)
 	Disabled   bool
 	Raised     bool
 	Unelevated bool
 	Outlined   bool
 	Dense      bool
-	Href       string
+
+	link *base.LinkMarkup
 }
 
 // Render implements the vecty.Component interface.
 func (c *B) Render() vecty.ComponentOrHTML {
+	c.link = base.ExtractMarkupFromLink(
+		c.Label.(*vecty.HTML),
+	)
+
 	rootMarkup := base.MarkupOnly(c.Root)
 	if c.Root != nil && rootMarkup == nil {
 		// User supplied root element.
@@ -52,7 +56,7 @@ func (c *B) Render() vecty.ComponentOrHTML {
 			base.MarkupIfNotNil(rootMarkup),
 		),
 		ico,
-		base.RenderStoredChild(c.Label),
+		base.RenderStoredChild(c.link.Child),
 	)
 }
 
@@ -66,7 +70,12 @@ func (c *B) Apply(h *vecty.HTML) {
 	vecty.Markup(
 		vecty.Class("mdc-button"),
 		prop.Type(prop.TypeButton),
-		event.Click(c.onClick),
+		vecty.MarkupIf(c.link.OnClick != nil && !c.link.PreventDefault,
+			event.Click(c.link.OnClick),
+		),
+		vecty.MarkupIf(c.link.OnClick != nil && c.link.PreventDefault,
+			event.Click(c.link.OnClick).PreventDefault(),
+		),
 		vecty.Property("disabled", c.Disabled),
 		vecty.MarkupIf(c.Raised,
 			vecty.Class("mdc-button--raised"),
@@ -81,10 +90,4 @@ func (c *B) Apply(h *vecty.HTML) {
 			vecty.Class("mdc-button--dense"),
 		),
 	).Apply(h)
-}
-
-func (c *B) onClick(e *vecty.Event) {
-	if c.OnClick != nil {
-		c.OnClick(c, e)
-	}
 }

--- a/demos/components/panel.go
+++ b/demos/components/panel.go
@@ -112,7 +112,6 @@ func (cp *ComponentCatalogPanel) renderResource(title, imageSource, url string) 
 	}
 
 	return &ul.Item{
-		Href: url,
 		Graphic: elem.Span(
 			vecty.Markup(
 				vecty.Class("resources-graphic"),
@@ -125,6 +124,11 @@ func (cp *ComponentCatalogPanel) renderResource(title, imageSource, url string) 
 				),
 			),
 		),
-		Primary: vecty.Text(title),
+		Primary: elem.Anchor(
+			vecty.Markup(
+				prop.Href(url),
+			),
+			vecty.Text(title),
+		),
 	}
 }

--- a/demos/components/sidebar.go
+++ b/demos/components/sidebar.go
@@ -5,6 +5,7 @@ import (
 	"github.com/hexops/vecty/prop"
 	"github.com/vecty-material/material/drawer"
 	"github.com/vecty-material/material/ul"
+	router "marwan.io/vecty-router"
 )
 
 type DemoLink struct {
@@ -33,10 +34,13 @@ func (cs *ComponentSidebar) Toggle() {
 }
 
 func (cs *ComponentSidebar) renderSidebarLink(link *DemoLink, index int) vecty.ComponentOrHTML {
-	return ul.ItemLink(
-		link.Url,
-		link.Name,
-	)
+	return &ul.Item{
+		Primary: router.Link(
+			link.Url,
+			link.Name,
+			router.LinkOptions{},
+		),
+	}
 }
 
 func (cs *ComponentSidebar) Render() vecty.ComponentOrHTML {

--- a/demos/views/menu.go
+++ b/demos/views/menu.go
@@ -1,8 +1,11 @@
 package views
 
 import (
+	"fmt"
+
 	"github.com/hexops/vecty"
 	"github.com/hexops/vecty/elem"
+	"github.com/hexops/vecty/event"
 
 	"github.com/vecty-material/material/button"
 	"github.com/vecty-material/material/demos/components"
@@ -73,11 +76,17 @@ func (bd *MenuDemos) Render() vecty.ComponentOrHTML {
 			vecty.Text("Anchored Menu"),
 		),
 		&button.B{
-			Label: vecty.Text("Open menu"),
-			OnClick: func(this *button.B, e *vecty.Event) {
-				menu.Open = !menu.Open
-				vecty.Rerender(menu)
-			},
+			Label: elem.Anchor(
+				vecty.Markup(
+					event.Click(func(e *vecty.Event) {
+						fmt.Println("button click")
+
+						menu.Open = !menu.Open
+						vecty.Rerender(menu)
+					}),
+				),
+				vecty.Text("Open menu"),
+			),
 		},
 		menu,
 	)

--- a/ul/list.go
+++ b/ul/list.go
@@ -145,13 +145,13 @@ func (c *Item) Render() vecty.ComponentOrHTML {
 	switch {
 	case c.Secondary != nil:
 		text = elem.Span(vecty.Markup(vecty.Class("mdc-list-item__text")),
-			c.Primary,
+			c.link.Child,
 			elem.Span(vecty.Markup(
 				vecty.Class("mdc-list-item__secondary-text")),
 				c.Secondary,
 			))
 	default:
-		text = c.Primary
+		text = c.link.Child
 	}
 
 	return vecty.Tag(tag,

--- a/ul/list.go
+++ b/ul/list.go
@@ -41,10 +41,7 @@ type Item struct {
 	Activated bool
 	Alt       string
 
-	primary            vecty.ComponentOrHTML
-	onclick            func(*vecty.Event)
-	href               string
-	callPreventDefault bool
+	link *base.SimplifiedMarkup
 }
 
 // Group is a vecty-material list-group component.
@@ -113,17 +110,12 @@ func (c *L) Apply(h *vecty.HTML) {
 
 // Render implements the vecty.Component interface.
 func (c *Item) Render() vecty.ComponentOrHTML {
-	primary, href, onclick, callPreventDefault := base.ExtractLinkAndListeners(
+	c.link = base.ExtractMarkup(
 		c.Primary.(*vecty.HTML),
 	)
 
-	c.primary = primary
-	c.href = href
-	c.onclick = onclick
-	c.callPreventDefault = callPreventDefault
-
 	tag := "li"
-	if c.href != "" {
+	if c.link.Href != "" {
 		tag = "a"
 	}
 
@@ -185,13 +177,13 @@ func (c *Item) Apply(h *vecty.HTML) {
 			vecty.Class("mdc-list-item--selected")),
 		vecty.MarkupIf(c.Activated,
 			vecty.Class("mdc-list-item--activated")),
-		vecty.MarkupIf(c.onclick != nil && !c.callPreventDefault,
-			event.Click(c.onclick),
+		vecty.MarkupIf(c.link.OnClick != nil && !c.link.PreventDefault,
+			event.Click(c.link.OnClick),
 		),
-		vecty.MarkupIf(c.onclick != nil && c.callPreventDefault,
-			event.Click(c.onclick).PreventDefault(),
+		vecty.MarkupIf(c.link.OnClick != nil && c.link.PreventDefault,
+			event.Click(c.link.OnClick).PreventDefault(),
 		),
-		vecty.MarkupIf(c.href != "", prop.Href(c.href)),
+		vecty.MarkupIf(c.link.Href != "", prop.Href(c.link.Href)),
 	).Apply(h)
 	c.MDC.RootElement = h
 }

--- a/ul/list.go
+++ b/ul/list.go
@@ -23,7 +23,6 @@ type L struct {
 	Dense          bool
 	Avatar         bool
 	NonInteractive bool
-	OnClick        func(thisL *L, thisI *Item, e *vecty.Event)
 	GroupSubheader string
 	twoLine        bool
 }
@@ -277,18 +276,6 @@ func (c *Group) listList() vecty.List {
 		}
 	}
 	return lists
-}
-
-func (c *L) wrapOnClick() func(i *Item, e *vecty.Event) {
-	return func(i *Item, e *vecty.Event) {
-		c.OnClick(c, i, e)
-	}
-}
-
-func (c *Item) wrapOnClick() func(e *vecty.Event) {
-	return func(e *vecty.Event) {
-		// c.OnClick(c, e)
-	}
 }
 
 func setupGraphicOrMeta(graphic vecty.ComponentOrHTML) vecty.ComponentOrHTML {

--- a/ul/list.go
+++ b/ul/list.go
@@ -41,7 +41,7 @@ type Item struct {
 	Activated bool
 	Alt       string
 
-	link *base.SimplifiedMarkup
+	link *base.LinkMarkup
 }
 
 // Group is a vecty-material list-group component.
@@ -110,7 +110,7 @@ func (c *L) Apply(h *vecty.HTML) {
 
 // Render implements the vecty.Component interface.
 func (c *Item) Render() vecty.ComponentOrHTML {
-	c.link = base.ExtractMarkup(
+	c.link = base.ExtractMarkupFromLink(
 		c.Primary.(*vecty.HTML),
 	)
 
@@ -142,16 +142,21 @@ func (c *Item) Render() vecty.ComponentOrHTML {
 	}
 
 	var text vecty.ComponentOrHTML
+	primary := c.Primary
+	if c.link.Href != "" && c.link.Child != nil {
+		primary = c.link.Child
+	}
+
 	switch {
 	case c.Secondary != nil:
 		text = elem.Span(vecty.Markup(vecty.Class("mdc-list-item__text")),
-			c.link.Child,
+			primary,
 			elem.Span(vecty.Markup(
 				vecty.Class("mdc-list-item__secondary-text")),
 				c.Secondary,
 			))
 	default:
-		text = c.link.Child
+		text = primary
 	}
 
 	return vecty.Tag(tag,


### PR DESCRIPTION
The purpose of this change is to allow specification of `href`, `onClick`, and `preventDefault` attributes through the usual method, rather than passing them to specific attributes.

For example, rather than this:

```go
&ul.Item{
    Primary: vecty.Text('test'),
    Href: '/some-url',
}
```

It should be possible to do this:

```go
&ul.Item{
    Primary: vecty.Anchor(
        vecty.Markup(
            prop.Href('/some-url'),
        ),
        vecty.Text('test'),
    )
),
```

The problem is that in order to accomplish this, we need to remove the inner text and then wrap it with our own elements. The two ways that we can accomplish this are:

1. Extract the markup from the existing anchor and re-apply it to a new anchor
2. Extract and remove the child `vecty.Text` from the existing anchor

Unfortunately, each of these methods poses a challenge. With the first method, we need to extract an event listener, which is a complex type that the `reflect` package cannot extract by default (probably because it would add another gc reference). With the second method, we would need to write to a private field, which is highly problematic. [this article][1] provides a very simple example, but zeroing a private list using the unsafe package may lead to a memory leak (though I am not sure). 


[1]: https://itnext.io/manipulating-private-fields-in-go-4da4ca525717 